### PR TITLE
Add URL and plugins configuration to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <description>
         Demo project for test coverage
     </description>
+    <url>https://jc.id.lv/demo-test-coverage/</url>
 
     <inceptionYear>2023</inceptionYear>
 
@@ -110,6 +111,18 @@
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>3.6.1</version>
                 </plugin>
+                <plugin>
+                    <artifactId>maven-scm-publish-plugin</artifactId>
+                    <version>3.2.1</version>
+                    <configuration>
+                        <scmBranch>gh-pages</scmBranch>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-changelog-plugin</artifactId>
+                    <version>2.3</version>
+                </plugin>
+
                 <!-- Third-party plugins -->
                 <plugin>
                     <groupId>org.jacoco</groupId>
@@ -121,6 +134,7 @@
                     <artifactId>spotbugs-maven-plugin</artifactId>
                     <version>4.8.1.0</version>
                 </plugin>
+
             </plugins>
         </pluginManagement>
 
@@ -137,6 +151,9 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-changelog-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 
@@ -148,6 +165,9 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-changelog-plugin</artifactId>
             </plugin>
         </plugins>
     </reporting>


### PR DESCRIPTION
Updated pom.xml by adding the project URL for better tracking. Added configurations of 'maven-scm-publish-plugin' and 'maven-changelog-plugin' to publish the test reports. The changes will be deployed to the 'gh-pages' branch.