### PR TITLE
Move Jacoco execution to optional Maven profile

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,5 +12,5 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 indent_size = 4
 
-[build.yml]
+[{build.yml,pom.xml}]
 indent_size = 2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,4 +34,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=rabestro_demo-test-coverage
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=rabestro_demo-test-coverage -Pcoverage

--- a/aggregate-report/pom.xml
+++ b/aggregate-report/pom.xml
@@ -36,21 +36,27 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>report-aggregate</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>report-aggregate</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+    <profiles>
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>report-aggregate</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report-aggregate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
Moved the execution of the Jacoco report to an optional Maven profile named 'coverage'. This change allows developers to optionally generate a Jacoco coverage report by activating the 'coverage' profile during build. To support this, added `-Pcoverage` flag in the GitHub action workflow file to ensure that Jacoco coverage reports are generated during CI builds. Updated `.editorconfig` to keep a consistent indentation size of 2 for 'pom.xml' besides 'build.yml'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted code formatting settings for better readability.
- **Chores**
	- Enhanced SonarQube analysis with coverage metrics for improved code quality monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->