### PR TITLE
Add XML format to Jacoco report & adjust paths and indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,5 +12,5 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 indent_size = 4
 
-[{build.yml,pom.xml}]
+[build.yml]
 indent_size = 2

--- a/aggregate-report/pom.xml
+++ b/aggregate-report/pom.xml
@@ -51,6 +51,11 @@
                                 <goals>
                                     <goal>report-aggregate</goal>
                                 </goals>
+                                <configuration>
+                                    <formats>
+                                        <format>XML</format>
+                                    </formats>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <sonar.organization>rabestro</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.coverage.jacoco.xmlReportPaths>
-            ${project.basedir}/aggregate-report/target/site/jacoco-aggregate/jacoco.xml
+            ${project.basedir}/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
         <sonar.language>java</sonar.language>
         <!-- Maven -->


### PR DESCRIPTION
Added XML format to Jacoco aggregate report in pom.xml, to support the compatibility with other tools that may require XML format. Adjusted the Jacoco XML report path in sonar settings to ensure accurate path for sonar analysis. Also, changed .editorconfig to reduce indentation size for 'build.yml' only, providing a clearer file structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted the indentation settings for improved readability and consistency across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->