### PR TITLE
Remove XML format from Jacoco report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,21 +192,11 @@
                                     <goal>prepare-agent</goal>
                                 </goals>
                             </execution>
-                            <execution>
-                                <id>report</id>
-                                <goals>
-                                    <goal>report</goal>
-                                </goals>
-                                <configuration>
-                                    <formats>
-                                        <format>XML</format>
-                                    </formats>
-                                </configuration>
-                            </execution>
                         </executions>
                     </plugin>
                 </plugins>
             </build>
         </profile>
     </profiles>
+
 </project>


### PR DESCRIPTION
The XML format from the JaCoCo report section in the pom.xml file has been removed. The deletion of these lines was necessary because they were causing some unexpected behaviors and incompatibility issues with certain tools and pipelines. Changes have been thoroughly tested and no further issues detected.