### PR TITLE
Update Jacoco report path and remove redundant property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,10 +49,9 @@
         <sonar.organization>rabestro</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.coverage.jacoco.xmlReportPaths>
-            ${project.basedir}/target/site/jacoco-aggregate/jacoco.xml
+            ../aggregate-report/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
         <sonar.language>java</sonar.language>
-        <sonar.report>${project.basedir}/target/site/jacoco-aggregate/jacoco.xml</sonar.report>
         <!-- Maven -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
The change modifies the Jacoco report path in the project properties of pom.xml file to refer to an aggregated report in a different module. This was updated to ensure that code coverage metrics include all project modules in their calculations. Additionally, a duplicate Sonar report property was removed as it was redundant and potentially confusing.