### PR TITLE
Add User class, update pom.xml files, and add LegalAgePredicate

### DIFF
--- a/bank-legacy/pom.xml
+++ b/bank-legacy/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.epam.engx</groupId>
+        <artifactId>demo-test-coverage</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>bank-legacy</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/bank-legacy/src/main/java/com/epam/engx/bank/LegalAgePredicate.java
+++ b/bank-legacy/src/main/java/com/epam/engx/bank/LegalAgePredicate.java
@@ -1,0 +1,14 @@
+package com.epam.engx.bank;
+
+import java.time.LocalDate;
+import java.util.function.Predicate;
+
+public class LegalAgePredicate implements Predicate<User> {
+
+    @Override
+    public boolean test(User user) {
+        int yearOfBirth = user.birthday().getYear();
+        int yearNow = LocalDate.now().getYear();
+        return yearNow - yearOfBirth >= 18;
+    }
+}

--- a/bank-legacy/src/main/java/com/epam/engx/bank/User.java
+++ b/bank-legacy/src/main/java/com/epam/engx/bank/User.java
@@ -1,0 +1,7 @@
+package com.epam.engx.bank;
+
+
+import java.time.LocalDate;
+
+public record User(String name, String surname, LocalDate birthday) {
+}

--- a/bank/pom.xml
+++ b/bank/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.epam.engx</groupId>
+        <artifactId>demo-test-coverage</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>bank</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,8 @@
     </developers>
 
     <modules>
+        <module>bank-legacy</module>
+        <module>bank</module>
         <module>exercism-forth</module>
         <module>legacy-forth</module>
         <module>legacy-forth-diffblue</module>
@@ -67,6 +69,8 @@
             ../aggregate-report/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
         <sonar.language>java</sonar.language>
+
+        <java.version>17</java.version>
         <!-- Maven -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -113,11 +117,13 @@
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>3.4.1</version>
                 </plugin>
+                <!-- Maven Compiler Plugin -->
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.11.0</version>
                     <configuration>
-                        <release>17</release>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Created a new User class in `bank-legacy/src/main/java/com/epam/engx/bank/User.java` with name, surname and birthday fields. Added `bank-legacy` and `bank` modules in `pom.xml`. The `pom.xml` files for the new modules have been created with dependencies including Junit Jupiter, Assertj Core, and Mockito Core. Java version is updated to 17 in `pom.xml`. Introduced a `LegalAgePredicate` class to validate if a user is of legal age (18 years or older).

These changes were necessary to expand the bank legacy package with new functionalities while ensuring applications build and test dependencies are properly managed. The User class provides a model for user data, and the LegalAgePredicate tests the legality of a user's age.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an age verification feature to ensure users meet the legal age requirement.
- **Documentation**
  - Added user information representation through a new immutable data structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->